### PR TITLE
Add text about patch labels for plugin repos

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,7 +44,7 @@ Review pull requests regularly, comment, suggest, reject, merge and close. Accep
 
 Manage labels, review issues regularly, and triage by labelling them. 
 
-All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, and `backport`. 
+All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, and `backport`. Plugin repositories have an additional `patch` label for tracking plugin-specific patches.
 
 Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -44,7 +44,7 @@ Review pull requests regularly, comment, suggest, reject, merge and close. Accep
 
 Manage labels, review issues regularly, and triage by labelling them. 
 
-All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, and `backport`. Plugin repositories have an additional `patch` label for tracking plugin-specific patches.
+All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0`, `v2.0.0`, `patch`, and `backport`.
 
 Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ Do not creating branches in the upstream repo, use your fork, for the exception 
 
 ## Release Labels
 
-Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `backport`. Use release labels to target an issue or a PR for a given release. See [MAINTAINERS](MAINTAINERS.md#triage-open-issues) for more information on triaging issues.
+Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `backport`. Plugin repositories have an additional `patch` label for plugin-specific patches. Use release labels to target an issue or a PR for a given release. See [MAINTAINERS](MAINTAINERS.md#triage-open-issues) for more information on triaging issues.
 
 ## Releasing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,7 @@ Do not creating branches in the upstream repo, use your fork, for the exception 
 
 ## Release Labels
 
-Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `backport`. Plugin repositories have an additional `patch` label for plugin-specific patches. Use release labels to target an issue or a PR for a given release. See [MAINTAINERS](MAINTAINERS.md#triage-open-issues) for more information on triaging issues.
+Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `patch` and `backport`. Use release labels to target an issue or a PR for a given release. See [MAINTAINERS](MAINTAINERS.md#triage-open-issues) for more information on triaging issues.
 
 ## Releasing
 


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
~~Adds text around plugins having a `patch` label to use for any plugin-specific patches (the 4th digit maintained by plugins). This way, the release labels (e.g., `v1.0.0`) can match core (only 3 digits).~~

Adds text around all repositories having an additional `patch` label to track patch commits.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
