### PR TITLE
Correct copyright notices to reflect Copyright OpenSearch Contributors.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,2 @@
+OpenSearch (https://opensearch.org/)
+Copyright OpenSearch Contributors

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ This project is licensed under the [Apache v2.0 License](LICENSE.txt).
 
 ## Copyright
 
-Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright OpenSearch Contributors. See [NOTICE](NOTICE.txt) for details.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

- Removed Amazon copyright, the correct copyright for OpenSearch projects is  "Copyright OpenSearch Contributors".
- Added NOTICE.txt and linked it from README.

Let's sweat the details, such as the language for the link, before I go and open two dozen issues across all repos to correct copyright notices.
  
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
