### PR TITLE
Added guide to backporting to release strategy

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,7 @@
   - [Feature Branches](#feature-branches)
 - [Release Labels](#release-labels)
 - [Releasing](#releasing)
+- [Backporting](#backporting)
 
 ## Overview
 
@@ -34,3 +35,36 @@ Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v
 The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [MAINTAINERS](MAINTAINERS.md).
 
 TODO
+
+## Backporting
+
+This project follows [semantic versioning](https://semver.org/spec/v2.0.0.html). Backwards-incompatible changes always result in a new major version and will __never__ be backported. Small improvements and features will be backported to a new minor version (e.g. `1.1`). Security fixes will be backported to a new patch version (e.g. `1.0.1`).
+
+Here are the commands we typically run to backport changes to release branches:
+
+1. Checkout the target release branch and pull the latest changes from `upstream`. In the examples below, our target release branch is `1.x`.
+
+```
+git checkout 1.x
+git pull upstream 1.x
+```
+
+2. Create a local branch for the backport. A convenient naming convention is _backport-\[PR-id\]-\[target-release-branch\]_.
+
+```
+git checkout -b backport-pr-xyz-1.x
+```
+
+3. Cherry-pick the commit to backport. Remember to include [DCO signoff](CONTRIBUTING.md#developer-certificate-of-origin).
+
+```
+git cherry-pick <commit-id> -s
+```
+
+4. Push the local branch to your fork.
+
+```
+git push origin backport-pr-xyz-1.x
+```
+
+5. Create a pull request for the change.


### PR DESCRIPTION
### Description
Added guide to backporting to release strategy
 
### Issues Resolved
N/A
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
