### PR TITLE
Clarified branching and versioning for plugins.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,7 +20,7 @@ Projects create a new branch when they need to start working on 2 separate versi
 
 [OpenSearch](https://github.com/opensearch-project/OpenSearch) typically tracks 3 releases in parallel. For example, given the last major release of 1.0, OpenSearch in this organization maintains the following active branches.
 
-* **main**: The _next major_ release, currently 2.0. This is the branch where all merges take place and code moves fast.
+* **main**: The _next major_ release, currently 2.0. This is the branch where all merges take place, and code moves fast.
 * **1.x**: The _next minor_ release, currently 1.1. Once a change is merged into `main`, decide whether to backport it to `1.x`.
 * **1.0**: The _current_ release, currently 1.0. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`. The next release out of this branch will be 1.0.1.
 
@@ -28,9 +28,10 @@ Label PRs with the next major version label (e.g. `2.0.0`) and merge changes int
 
 ### Plugin Branching
 
-Plugins, such as [job-scheduler](https://github.com/opensearch-project/job-scheduler) aren't as active as OpenSearch, and typically track 2 releases in parallel instead of 3. For example, given the last major release of 1.0, job-scheduler maintains the following active branches.
+Plugins, such as [job-scheduler](https://github.com/opensearch-project/job-scheduler) aren't as active as OpenSearch, and typically track 2 releases in parallel instead of 3. This still translates into 3 branches. For example, given the last major release of 1.0, job-scheduler maintains the following.
 
-* **main**: The _next_ release, currently 1.1. This is the branch where all merges take place and code moves fast.
+* **main**: The _next_ release, currently 1.1. This is the branch where all merges take place, and code moves fast.
+* **1.x**: A common parent branch for the series of 1.x releases. This is where 1.x patches will be made when `main` becomes 2.0.
 * **1.0**: The _current_ release, currently 1.0. This branch's parent is `1.x` to make future merges easier. 'In between minor releases, only hotfixes (e.g. security) are backported to `1.0`. The next release out of this branch will be 1.0.1.
 
 ### Versioning

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,9 @@
 - [Overview](#overview)
 - [Branching](#branching)
-  - [Release Branching](#release-branching)
-  - [Feature Branches](#feature-branches)
+    - [OpenSearch Branching](#opensearch-branching)
+    - [Plugin Branching](#plugin-branching)
+    - [Versioning](#versioning)
+    - [Feature Branches](#feature-branches)
 - [Release Labels](#release-labels)
 - [Releasing](#releasing)
 - [Backporting](#backporting)
@@ -12,15 +14,31 @@ This document explains the release strategy for artifacts in this organization.
 
 ## Branching
 
-### Release Branching
+Projects create a new branch when they need to start working on 2 separate versions of the product, with the `main` branch being the furthermost release. 
 
-Given the current major release of 1.0, projects in this organization maintain the following active branches.
+### OpenSearch Branching
 
-* **main**: The next _major_ release. This is the branch where all merges take place and code moves fast.
-* **1.x**: The next _minor_ release. Once a change is merged into `main`, decide whether to backport it to `1.x`.
-* **1.0**: The _current_ release. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`.
+[OpenSearch](https://github.com/opensearch-project/OpenSearch) typically tracks 3 releases in parallel. For example, given the last major release of 1.0, OpenSearch in this organization maintains the following active branches.
+
+* **main**: The _next major_ release, currently 2.0. This is the branch where all merges take place and code moves fast.
+* **1.x**: The _next minor_ release, currently 1.1. Once a change is merged into `main`, decide whether to backport it to `1.x`.
+* **1.0**: The _current_ release, currently 1.0. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`. The next release out of this branch will be 1.0.1.
 
 Label PRs with the next major version label (e.g. `2.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `1.x` and `1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+
+### Plugin Branching
+
+Plugins, such as [job-scheduler](https://github.com/opensearch-project/job-scheduler) aren't as active as OpenSearch, and typically track 2 releases in parallel instead of 3. For example, given the last major release of 1.0, job-scheduler maintains the following active branches.
+
+* **main**: The _next_ release, currently 1.1. This is the branch where all merges take place and code moves fast.
+* **1.0**: The _current_ release, currently 1.0. This branch's parent is `1.x` to make future merges easier. 'In between minor releases, only hotfixes (e.g. security) are backported to `1.0`. The next release out of this branch will be 1.0.1.
+
+### Versioning
+
+Versions are incremented as soon as development starts on a given version to avoid confusion. In the examples above versions are as follows.
+
+* OpenSearch: `main` = 2.0, `1.x` = 1.1, and `1.0` = 1.0
+* job-scheduler: `main` = 1.1, `1.0` = 1.0
 
 ### Feature Branches
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I attempted to clarify what we're doing right now for 1.1.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
