### PR TITLE
Adding maintainers to opensearch-project.

### DIFF
--- a/ADMINS.md
+++ b/ADMINS.md
@@ -1,3 +1,11 @@
+- [Overview](#overview)
+- [Current Admins](#current-admins)
+- [Admin Responsibilities](#admin-responsibilities)
+  - [Prioritize Security](#prioritize-security)
+  - [Enforce Code of Conduct](#enforce-code-of-conduct)
+  - [Add/Remove Maintainers](#addremove-maintainers)
+  - [Adopt Organizational Best Practices](#adopt-organizational-best-practices)
+
 ## Overview
 
 This document explains who the admins are (see below), what they do in this repo, and how they should be doing it. If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
@@ -21,6 +29,10 @@ Note that this repository is monitored and supported 24/7 by Amazon Security, se
 ### Enforce Code of Conduct
 
 Act on [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md) violations by revoking access, and blocking malicious actors.
+
+### Add/Remove Maintainers
+
+Perform administrative tasks, such as [adding](MAINTAINERS.md#adding-a-new-maintainer) and [removing maintainers](MAINTAINERS.md#removing-a-maintainer).
 
 ### Adopt Organizational Best Practices
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -97,7 +97,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive maintainer votes are necessary, and no vetoes. In rare cases when there are fewer than three maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
+Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
 
 The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
@@ -111,7 +111,7 @@ Individuals accept the nomination by replying, or commenting, for example _"Than
 
 ### Addition
 
-Upon receiving three positive maintainer votes, and no vetoes, from other maintainers, and after having privately confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. The pull request is approved and merged.
+Upon receiving three positive (+1) maintainer votes, and no vetoes (-1), from other maintainers, and after having privately confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. The pull request is approved and merged.
 
 > _Content from the above nomination._
 > 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,7 +103,8 @@ The nomination should clearly identify the person with their real name and a lin
 
 ### Interest
 
-Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
+Upon receiving at least three positive (+1) maintainer votes, and no vetoes
+(-1), from existing maintainers after a one week period, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
 
 > This is great work! Based on your valuable contribution and ongoing engagement with the project, the current maintainers invite you to become a co-maintainer for this project. Please respond and let us know if you accept the invitation to become maintainer.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,17 @@
   - [Release Frequently](#release-frequently)
   - [Promote Other Maintainers](#promote-other-maintainers)
   - [Describe the Repo](#describe-the-repo)
-  
+- [Becoming a Maintainer](#becoming-a-maintainer)
+  - [Preparation](#preparation)
+  - [Interest](#interest)
+  - [Public Confirmation](#public-confirmation)
+  - [Maintainer Decision](#maintainer-decision)
+  - [Adding the New Maintainer](#adding-the-new-maintainer)
+- [Removing a Maintainer](#removing-a-maintainer)
+  - [Moving On](#moving-on)
+  - [Inactivity](#inactivity)
+  - [Negative Impact on the Project](#negative-impact-on-the-project)
+   
 ## Overview
 
 This document explains who the maintainers are (see below), what they do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
@@ -77,8 +87,73 @@ Make frequent project releases to the community.
 
 ### Promote Other Maintainers
 
-Assist, add, and remove [MAINTAINERS](MAINTAINERS.md). Exercise good judgement, and propose high quality contributors to become co-maintainers.
+Assist, add, and remove [MAINTAINERS](MAINTAINERS.md). Exercise good judgement, and propose high quality contributors to become co-maintainers. See [Becoming a Maintainer](#becoming-a-maintainer) for more information.
 
 ### Describe the Repo
 
 Make sure the repo has a well-written, accurate, and complete description. See [opensearch-project/.github#38](https://github.com/opensearch-project/.github/issues/38) for some helpful tips to describe your repo.
+
+## Becoming a Maintainer
+
+You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any project, and being nominated by an existing maintainer.
+
+### Nomination
+
+Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. Any disagreements can be escalated to the repo [Admin](ADMINS.md).
+
+> I propose inviting Vacha Shah ([@vachashah](https://github.com/vachashah)) as a co-maintainer on [opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenSearch). 
+> 
+> Vacha has contributed a lot of automation across many repositories.
+> 
+> - https://github.com/opensearch-project/OpenSearch/pull/877 — Added a broken link checker
+> - https://github.com/opensearch-project/OpenSearch/issues/894 — Fixed broken links across the OpenSearch-Project
+> - https://github.com/opensearch-project/opensearch-build/pull/17  — Updated labels across all OpenSearch repos
+> - https://github.com/opensearch-project/opensearch-plugins/pull/70 — Updated plugin documentation
+> 
+> Vacha has worked tenaciously on non-glamorous tasks, because they raise the overall Engineering bar for the entire project. 
+
+### Interest
+
+Upon receiving at least 3 positive maintainer votes, and no vetoes, from other maintainers within a maximum period of 2 weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which typically happens via e-mail obtained via DCO, but may also be a comment to a pull request, following a substantial contribution.
+
+> This is great work, Vacha! Would you be interested in becoming a [co-maintainer](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) on this project? I’d be honored to nominate you.
+
+Individuals accept the nomination by replying, or commenting, for example _"Thank you! I would love to."_
+
+### Public Confirmation
+
+Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a public issue in order to make the vote visible to the community. 
+
+> _Content from the above nomination._
+> 
+> Here is my +1.
+> 
+> If you support this nomination, please add your +1 or a comment. 
+> 
+> If you do not support this nomination, we invite you to e-mail all/some of the current [project maintainers](https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md) in the next 2 weeks. We will keep your feedback private to this group and discuss offline. We will not publicly post the reasons for a decision not to add this co-maintainer, or publicize your name. 
+> 
+> Anyone, including maintainers, can publicly add +1s as requested in the nomination issue if they support the nomination or contact the maintainers in private if they oppose. The issue stays open for 2 weeks.
+
+### Maintainer Decision
+
+If a positive decision has been reached, the nomination is accepted and the nominating maintainer can thus comment on the issue with _"maintainers has been added"_. If a decision cannot be reached for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary.
+
+### Adding the New Maintainer 
+
+The Repo [Admin](ADMINS.md) adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
+
+## Removing a Maintainer
+
+Removing a maintainer is a disruptive action that the community of maintainers should not undertake lightly. There are several reasons a maintainer might be removed from the project, such as inactivity, or taking actions that negatively impact the project.
+
+### Moving On
+
+There are plenty of reasons that might cause someone to want to take a step back or even a hiatus from a project. Existing maintainers can choose to leave the project at any time, with or without reason, by making a pull request to move themselves to the "Emeritus" section of MAINTAINERS.md, and asking an admin to remove their permissions.
+
+### Inactivity
+
+If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo owner to contact the inactive maintainer to check-in. If the inactive maintainer responds and intends to reengage, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo owner can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
+
+### Negative Impact on the Project
+
+Actions that negatively impact the project will be handled by the Admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations and security risks.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,7 +103,7 @@ The nomination should clearly identify the person with their real name and a lin
 
 ### Interest
 
-Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which happens via private e-mail message message, but may also be a comment to a pull request, following a substantial contribution.
+Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which happens via private e-mail message, but may also be a comment to a pull request, following a substantial contribution.
 
 > This is great work! Based on your valuable contribution and ongoing engagement with the project, the current maintainers invite you to become a co-maintainer for this project. Please respond and let us know if you accept the invitation to become maintainer.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -122,7 +122,7 @@ Individuals accept the nomination by replying, or commenting, for example _"Than
 
 ### Public Confirmation
 
-Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a public issue in order to make the vote visible to the community. 
+Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. This makes the vote visible to the community. 
 
 > _Content from the above nomination._
 > 
@@ -132,15 +132,15 @@ Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainer
 > 
 > If you do not support this nomination, we invite you to e-mail all/some of the current [project maintainers](https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md) in the next 2 weeks. We will keep your feedback private to this group and discuss offline. We will not publicly post the reasons for a decision not to add this co-maintainer, or publicize your name. 
 > 
-> Anyone, including maintainers, can publicly add +1s as requested in the nomination issue if they support the nomination or contact the maintainers in private if they oppose. The issue stays open for 2 weeks.
+> Anyone, including maintainers, can publicly add +1s as requested in the nomination issue if they support the nomination or contact the maintainers in private if they oppose. The pull request stays open for 2 weeks.
 
 ### Maintainer Decision
 
-If a positive decision has been reached, the nomination is accepted and the nominating maintainer can thus comment on the issue with _"maintainers has been added"_. If a decision cannot be reached for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary.
+If a positive decision has been reached, the nomination is accepted. If a decision cannot be reached for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary, and the pull request is closed.
 
 ### Adding a New Maintainer
 
-The repo admin adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
+The repo admin adjusts the new maintainer’s permissions accordingly, and merges the pull request to MAINTAINERS.md.
 
 ## Removing a Maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -143,7 +143,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and reengages, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
+If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and reengages, no action is required. If the maintainer does not respond after several weeks, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
 
 If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -105,7 +105,7 @@ The nomination should clearly identify the person with their real name and a lin
 
 Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which happens via private e-mail message message, but may also be a comment to a pull request, following a substantial contribution.
 
-> This is great work! Based on your ongoing engagement with the project, the current maintainers now invite you to become a co-maintainer for this project. Please respond and let us know if you would like to become maintainer.
+> This is great work! Based on your valuable contribution and ongoing engagement with the project, the current maintainers invite you to become a co-maintainer for this project. Please respond and let us know if you accept the invitation to become maintainer.
 
 Individuals accept the nomination by replying, or commenting, for example _"Thank you! I would love to."_
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -143,7 +143,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), their account may be deactivated by the repo admin for security reasons. A maintainer can reach out to the repo admin to get their permissions reinstated.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), the repo admin may revoke maintainer level access to the repository for security reasons. A maintainer can reach out to the repo admin to get their permissions reinstated.
 
 If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,7 +99,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. Any disagreements can be escalated to the repo [Admin](ADMINS.md).
+Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are less than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo [Admin](ADMINS.md).
 
 > I propose inviting Vacha Shah ([@vachashah](https://github.com/vachashah)) as a co-maintainer on [opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenSearch). 
 > 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -113,7 +113,7 @@ Individuals accept the nomination by replying, or commenting, for example _"Than
 
 ### Public Confirmation
 
-Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. This makes the proposal and the vote visible to the community.
+Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md, and perform a final vote similar to the nomination process. If the nomination still has 3 positive votes, and no vetoes, from other maintainers, the nomination is accepted. The positive maintainer voters should approve the pull request to show support.
 
 > _Content from the above nomination._
 > 
@@ -127,7 +127,7 @@ Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainer
 
 ### Maintainer Decision
 
-If a positive decision has been reached, the nomination is accepted. If a decision cannot be reached for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary, and the pull request is closed.
+If a positive decision has been reached, the nomination is accepted. If the maintainers cannot reach a positive decision for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary, and the pull request is closed.
 
 ### Adding a New Maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,7 +99,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are less than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
+Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are fewer than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
 
 The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
@@ -135,7 +135,7 @@ The repo admin adjusts the new maintainer’s permissions accordingly, and merge
 
 ## Removing a Maintainer
 
-Removing a maintainer is a disruptive action that the community of maintainers should not undertake lightly. There are several reasons a maintainer might be removed from the project, such as inactivity, or taking actions that negatively impact the project.
+Removing a maintainer is a disruptive action that the community of maintainers should not undertake lightly. There are several reasons a maintainer might be removed from the project, such as violating the [code of conduct](https://github.com/opensearch-project/.github/blob/main/CODE_OF_CONDUCT.md), or taking other actions that negatively impact the project.
 
 ### Moving On
 
@@ -149,4 +149,4 @@ If the repo is left without any maintainers, either by maintainer inactivity or 
 
 ### Negative Impact on the Project
 
-Actions that negatively impact the project will be handled by the admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful actions, and security risks.
+Actions that negatively impact the project will be handled by the admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -140,7 +140,7 @@ If a positive decision has been reached, the nomination is accepted and the nomi
 
 ### Adding the New Maintainer 
 
-The Repo Admin adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
+The repo admin adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
 
 ## Removing a Maintainer
 
@@ -156,4 +156,4 @@ If the maintainers on the project notice that another maintainer is no longer an
 
 ### Negative Impact on the Project
 
-Actions that negatively impact the project will be handled by the Admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful actions, and security risks.
+Actions that negatively impact the project will be handled by the admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful actions, and security risks.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -143,7 +143,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and intends to reengage, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
+If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and reengages, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
 
 If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -101,16 +101,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are less than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
 
-> I propose inviting Vacha Shah ([@vachashah](https://github.com/vachashah)) as a co-maintainer on [opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenSearch). 
-> 
-> Vacha has contributed a lot of automation across many repositories.
-> 
-> - https://github.com/opensearch-project/OpenSearch/pull/877 — Added a broken link checker
-> - https://github.com/opensearch-project/OpenSearch/issues/894 — Fixed broken links across the OpenSearch-Project
-> - https://github.com/opensearch-project/opensearch-build/pull/17  — Updated labels across all OpenSearch repos
-> - https://github.com/opensearch-project/opensearch-plugins/pull/70 — Updated plugin documentation
-> 
-> Vacha has worked tenaciously on non-glamorous tasks, because they raise the overall Engineering bar for the entire project. 
+The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
 ### Interest
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,8 +103,7 @@ The nomination should clearly identify the person with their real name and a lin
 
 ### Interest
 
-Upon receiving at least three positive (+1) maintainer votes, and no vetoes
-(-1), from existing maintainers after a one week period, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
+Upon receiving at least three positive (+1) maintainer votes, and no vetoes (-1), from existing maintainers after a one week period, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
 
 > This is great work! Based on your valuable contribution and ongoing engagement with the project, the current maintainers invite you to become a co-maintainer for this project. Please respond and let us know if you accept the invitation to become maintainer.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,7 +103,7 @@ The nomination should clearly identify the person with their real name and a lin
 
 ### Interest
 
-Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which happens via private e-mail message, but may also be a comment to a pull request, following a substantial contribution.
+Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
 
 > This is great work! Based on your valuable contribution and ongoing engagement with the project, the current maintainers invite you to become a co-maintainer for this project. Please respond and let us know if you accept the invitation to become maintainer.
 
@@ -111,7 +111,7 @@ Individuals accept the nomination by replying, or commenting, for example _"Than
 
 ### Addition
 
-Upon receiving three positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. The pull request is approved and merged.
+Upon receiving three positive maintainer votes, and no vetoes, from other maintainers, and after having privately confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. The pull request is approved and merged.
 
 > _Content from the above nomination._
 > 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,9 +16,7 @@
 - [Becoming a Maintainer](#becoming-a-maintainer)
   - [Nomination](#nomination)
   - [Interest](#interest)
-  - [Public Confirmation](#public-confirmation)
-  - [Maintainer Decision](#maintainer-decision)
-  - [Adding a New Maintainer](#adding-a-new-maintainer)
+  - [Addition](#addition)
 - [Removing a Maintainer](#removing-a-maintainer)
   - [Moving On](#moving-on)
   - [Inactivity](#inactivity)
@@ -51,7 +49,7 @@ Note that this repository is monitored and supported 24/7 by Amazon Security, se
 
 ### Review Pull Requests
 
-Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests. Provide code reviews and guidance on incomming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
+Review pull requests regularly, comment, suggest, reject, merge and close. Accept only high quality pull-requests. Provide code reviews and guidance on incoming pull requests. Don't let PRs be stale and do your best to be helpful to contributors.
 
 ### Triage Open Issues
 
@@ -111,27 +109,15 @@ Upon receiving at least three positive maintainer votes, and no vetoes, from oth
 
 Individuals accept the nomination by replying, or commenting, for example _"Thank you! I would love to."_
 
-### Public Confirmation
+### Addition
 
-Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md, and perform a final vote similar to the nomination process. If the nomination still has 3 positive votes, and no vetoes, from other maintainers, the nomination is accepted. The positive maintainer voters should approve the pull request to show support.
+Upon receiving three positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. The pull request is approved and merged.
 
 > _Content from the above nomination._
 > 
-> Here is my +1.
-> 
-> If you support this nomination, please add your +1 or a comment. 
-> 
-> If you do not support this nomination, we invite you to e-mail all/some of the current [project maintainers](https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md) in the next two weeks. We will keep your feedback private to this group and discuss offline. We will not publicly post the reasons for a decision not to add this co-maintainer, or publicize your name.
-> 
-> Anyone, including maintainers, can publicly add +1s as requested in the nomination issue if they support the nomination or contact the maintainers in private if they oppose. The pull request stays open for two weeks.
+> The maintainers have voted and agreed to this nomination.
 
-### Maintainer Decision
-
-If a positive decision has been reached, the nomination is accepted. If the maintainers cannot reach a positive decision for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary, and the pull request is closed.
-
-### Adding a New Maintainer
-
-The repo admin adjusts the new maintainer’s permissions accordingly, and merges the pull request to MAINTAINERS.md.
+The repo admin adjusts the new maintainer’s permissions accordingly, and merges the pull request.
 
 ## Removing a Maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,7 @@
   - [Interest](#interest)
   - [Public Confirmation](#public-confirmation)
   - [Maintainer Decision](#maintainer-decision)
-  - [Adding the New Maintainer](#adding-the-new-maintainer)
+  - [Adding a New Maintainer](#adding-a-new-maintainer)
 - [Removing a Maintainer](#removing-a-maintainer)
   - [Moving On](#moving-on)
   - [Inactivity](#inactivity)
@@ -138,7 +138,7 @@ Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainer
 
 If a positive decision has been reached, the nomination is accepted and the nominating maintainer can thus comment on the issue with _"maintainers has been added"_. If a decision cannot be reached for any reason, the nomination is rejected with _"a decision could not be reached"_ with no further explanation necessary.
 
-### Adding the New Maintainer 
+### Adding a New Maintainer
 
 The repo admin adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,7 +99,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are less than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo [Admin](ADMINS.md).
+Any current maintainer starts an e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are less than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
 
 > I propose inviting Vacha Shah ([@vachashah](https://github.com/vachashah)) as a co-maintainer on [opensearch-project/OpenSearch](https://github.com/opensearch-project/OpenSearch). 
 > 
@@ -152,7 +152,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo owner to contact the inactive maintainer to check-in. If the inactive maintainer responds and intends to reengage, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo owner can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
+If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and intends to reengage, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
 
 ### Negative Impact on the Project
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -143,7 +143,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and reengages, no action is required. If the maintainer does not respond after several weeks, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), their account may be deactivated by the repo admin for security reasons. A maintainer can reach out to the repo admin to get their permissions reinstated.
 
 If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -113,7 +113,7 @@ Individuals accept the nomination by replying, or commenting, for example _"Than
 
 ### Public Confirmation
 
-Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. This makes the vote visible to the community. 
+Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainers, and after having confirmed interest with the nominee, the maintainer opens a pull request adding the proposed co-maintainer to MAINTAINERS.md. This makes the proposal and the vote visible to the community.
 
 > _Content from the above nomination._
 > 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -116,7 +116,7 @@ Any current maintainer starts an e-mail thread (until we have a better mechanism
 
 Upon receiving at least 3 positive maintainer votes, and no vetoes, from other maintainers within a maximum period of 2 weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which typically happens via e-mail obtained via DCO, but may also be a comment to a pull request, following a substantial contribution.
 
-> This is great work, Vacha! Would you be interested in becoming a [co-maintainer](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) on this project? I’d be honored to nominate you.
+> This is great work! Based on your ongoing contributions to the project we have decided that we'd like to invite you to become a co-maintainer for this project. Please let us know whether you accept this nomination.
 
 Individuals accept the nomination by replying, or commenting, for example _"Thank you! I would love to."_
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -121,7 +121,7 @@ The repo admin adjusts the new maintainer’s permissions accordingly, and merge
 
 ## Removing a Maintainer
 
-Removing a maintainer is a disruptive action that the community of maintainers should not undertake lightly. There are several reasons a maintainer might be removed from the project, such as violating the [code of conduct](https://github.com/opensearch-project/.github/blob/main/CODE_OF_CONDUCT.md), or taking other actions that negatively impact the project.
+Removing a maintainer is a disruptive action that the community of maintainers should not undertake lightly. There are several reasons a maintainer will be removed from the project, such as violating the [code of conduct](https://github.com/opensearch-project/.github/blob/main/CODE_OF_CONDUCT.md), or taking other actions that negatively impact the project.
 
 ### Moving On
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -156,4 +156,4 @@ If the maintainers on the project notice that another maintainer is no longer an
 
 ### Negative Impact on the Project
 
-Actions that negatively impact the project will be handled by the Admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations and security risks.
+Actions that negatively impact the project will be handled by the Admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful actions, and security risks.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -103,7 +103,7 @@ The nomination should clearly identify the person with their real name and a lin
 
 ### Interest
 
-Upon receiving at least three positive (+1) maintainer votes, and no vetoes (-1), from existing maintainers after a one week period, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
+Upon receiving at least three positive (+1) maintainer votes, and no vetoes (-1), from existing maintainers after a one week period, the nominating maintainer asks the nominee whether they might be interested in becoming a maintainer on the repository via private e-mail message.
 
 > This is great work! Based on your valuable contribution and ongoing engagement with the project, the current maintainers invite you to become a co-maintainer for this project. Please respond and let us know if you accept the invitation to become maintainer.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -140,7 +140,7 @@ If a positive decision has been reached, the nomination is accepted and the nomi
 
 ### Adding the New Maintainer 
 
-The Repo [Admin](ADMINS.md) adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
+The Repo Admin adjusts the new maintainer’s permissions accordingly. The nominating maintainer opens a pull request to add the new maintainer to MAINTAINERS.md, and closes the nomination issue when that is merged and the individual has been given maintainer-level permissions.
 
 ## Removing a Maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,14 +7,14 @@
   - [Triage Open Issues](#triage-open-issues)
   - [Be Responsive](#be-responsive)
   - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
-  - [Add Continious Integration Checks](#add-continious-integration-checks)
+  - [Add Continuous Integration Checks](#add-continuous-integration-checks)
     - [Developer Certificate of Origin Workflow](#developer-certificate-of-origin-workflow)
   - [Use Semver](#use-semver)
   - [Release Frequently](#release-frequently)
   - [Promote Other Maintainers](#promote-other-maintainers)
   - [Describe the Repo](#describe-the-repo)
 - [Becoming a Maintainer](#becoming-a-maintainer)
-  - [Preparation](#preparation)
+  - [Nomination](#nomination)
   - [Interest](#interest)
   - [Public Confirmation](#public-confirmation)
   - [Maintainer Decision](#maintainer-decision)
@@ -69,7 +69,7 @@ Respond to enhancement requests, and forum posts. Allocate time to reviewing and
 
 Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches. 
 
-### Add Continious Integration Checks
+### Add Continuous Integration Checks
 
 Add integration checks that validate pull requests and pushes to ease the burden on Pull Request reviewers.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,15 +99,15 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mails can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least 3 positive maintainer votes are necessary, and no vetoes. In rare cases when there are fewer than 3 maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
+Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive maintainer votes are necessary, and no vetoes. In rare cases when there are fewer than three maintainers, the positive votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
 
 The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
 ### Interest
 
-Upon receiving at least 3 positive maintainer votes, and no vetoes, from other maintainers within a maximum period of 2 weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which typically happens via e-mail obtained via DCO, but may also be a comment to a pull request, following a substantial contribution.
+Upon receiving at least three positive maintainer votes, and no vetoes, from other maintainers within a maximum period of two weeks, the nominating maintainer asks a potential nominee whether they might be interested in becoming a maintainer on the repository, which happens via private e-mail message message, but may also be a comment to a pull request, following a substantial contribution.
 
-> This is great work! Based on your ongoing contributions to the project we have decided that we'd like to invite you to become a co-maintainer for this project. Please let us know whether you accept this nomination.
+> This is great work! Based on your ongoing engagement with the project, the current maintainers now invite you to become a co-maintainer for this project. Please respond and let us know if you would like to become maintainer.
 
 Individuals accept the nomination by replying, or commenting, for example _"Thank you! I would love to."_
 
@@ -121,9 +121,9 @@ Upon receiving 3 positive maintainer votes, and no vetoes, from other maintainer
 > 
 > If you support this nomination, please add your +1 or a comment. 
 > 
-> If you do not support this nomination, we invite you to e-mail all/some of the current [project maintainers](https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md) in the next 2 weeks. We will keep your feedback private to this group and discuss offline. We will not publicly post the reasons for a decision not to add this co-maintainer, or publicize your name. 
+> If you do not support this nomination, we invite you to e-mail all/some of the current [project maintainers](https://github.com/opensearch-project/OpenSearch/blob/main/MAINTAINERS.md) in the next two weeks. We will keep your feedback private to this group and discuss offline. We will not publicly post the reasons for a decision not to add this co-maintainer, or publicize your name.
 > 
-> Anyone, including maintainers, can publicly add +1s as requested in the nomination issue if they support the nomination or contact the maintainers in private if they oppose. The pull request stays open for 2 weeks.
+> Anyone, including maintainers, can publicly add +1s as requested in the nomination issue if they support the nomination or contact the maintainers in private if they oppose. The pull request stays open for two weeks.
 
 ### Maintainer Decision
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -145,6 +145,8 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 If the maintainers on the project notice that another maintainer is no longer an active or visible member of the community, the first step will be to tell the repo admin to contact the inactive maintainer to check-in. If the inactive maintainer responds and intends to reengage, no action is required. If the maintainer does not respond after a week, or indicates they no longer wish to be a maintainer, the repo admin can remove the inactive maintainer’s permissions and make a pull request to add them to the "Emeritus" section of the MAINTAINERS.md.
 
+If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
+
 ### Negative Impact on the Project
 
 Actions that negatively impact the project will be handled by the admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful actions, and security risks.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I'd like to propose a lightweight process for adding maintainers to opensearch-project repos. 

Note that the 3 positive votes and no vetoes comes from [Apache](https://httpd.apache.org/dev/voting.html).
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
