### PR TITLE
Standardized template layout.

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -5,27 +5,20 @@ title: '[BUG]'
 labels: 'bug, untriaged'
 assignees: ''
 ---
-
 ### What is the bug?
-A clear and concise description of the bug.
+_A clear and concise description of the bug._
 
 ### How can one reproduce the bug?
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+_Steps to reproduce the behavior._
 
 ### What is the expected behavior?
-A clear and concise description of what you expected to happen.
+_A clear and concise description of what you expected to happen._
 
 ### What is your host/environment?
- - OS: [e.g. iOS]
- - Version [e.g. 22]
- - Plugins
+_Operating system, version._
 
 ### Do you have any screenshots?
-If applicable, add screenshots to help explain your problem.
+_If applicable, add screenshots to help explain your problem._
 
 ### Do you have any additional context?
-Add any other context about the problem.
+_Add any other context about the problem._

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_TEMPLATE.md
@@ -6,13 +6,13 @@ labels: 'enhancement, untriaged'
 assignees: ''
 ---
 ### Is your feature request related to a problem?
-A clear and concise description of what the problem is, e.g. _I'm always frustrated when [...]_
+_A clear and concise description of what the problem is, e.g. I'm always frustrated when [...]._
 
 ### What solution would you like?
-A clear and concise description of what you want to happen.
+_A clear and concise description of what you want to happen._
 
 ### What alternatives have you considered?
-A clear and concise description of any alternative solutions or features you've considered.
+_A clear and concise description of any alternative solutions or features you've considered._
 
 ### Do you have any additional context?
-Add any other context or screenshots about the feature request here.
+_Add any other context or screenshots about the feature request here._

--- a/.github/ISSUE_TEMPLATE/PROPOSAL_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/PROPOSAL_TEMPLATE.md
@@ -5,7 +5,6 @@ title: '[PROPOSAL]'
 labels: proposal
 assignees: ''
 ---
-
 ### What are you proposing?
 _In a few sentences, describe the feature and its core capabilities._
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,5 @@ _Describe what this change achieves._
 ### Issues Resolved
 _List any issues this PR will resolve, e.g. Closes [...]._ 
 
-### Check List
-- [x] Commits are signed per the DCO using `git commit --signoff`.
-
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ### Description
-[Describe what this change achieves]
- 
+_Describe what this change achieves._
+
 ### Issues Resolved
-[List any issues this PR will resolve]
- 
+_List any issues this PR will resolve, e.g. Closes [...]._ 
+
 ### Check List
-- [ ] Commits are signed per the DCO using --signoff 
+- [x] Commits are signed per the DCO using `git commit --signoff`.
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description
- Standardize template layouts to have the small text italicised.
- Removed the annoying DCO checkbox from the "checklist" since we have automated DCO checks.
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
