### PR TITLE
Expand SPDX headers to include licensing contributions language.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@
   - [Contributing Code](#contributing-code)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
 - [License Headers](#license-headers)
+  - [Java](#java)
+  - [Python, Ruby, Shell](#python-ruby-shell)
 - [Review Process](#review-process)
 
 ## Contributing to OpenSearch
@@ -100,19 +102,22 @@ New files in your code contributions should contain the following license header
 /*
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
- */
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+*/
 ```
 
-### Python
+### Python, Ruby, Shell
 ```
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
-```
-
-### Shell
-```
-# Copyright OpenSearch Contributors
-# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
 ```
 
 ## Review Process


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

See https://github.com/opensearch-project/opensearch-java/pull/178 for where I came from. I re-confirmed that we do want both a copyright and attribution in the SPDX header. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
