### PR TITLE
Add automatic labeling section with template examples, and a github workflow to add 'untriaged' label on new issues

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -1,0 +1,19 @@
+name: Apply 'untriaged' label during issue lifecycle
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['untriaged']
+            })

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -60,7 +60,7 @@ Use labels to target an issue or a PR for a given release, add `help wanted` to 
 
 #### Automatically Label Issues
 
-There are many tools available in GitHub for controlling labels on issues and pull requests.  Use standard issue templates in the [./.github/ISSUE_TEMPLATE](./.github/ISSUE_TEMPLATE) directory to apply appropriate labels such as `bug` and `untriaged`.  Repositories can choose to use GitHub actions such as [add-untriaged.yml](.github\workflows\add-untriaged.yml) to apply labels automatically.
+There are many tools available in GitHub for controlling labels on issues and pull requests.  Use standard issue templates in the [./.github/ISSUE_TEMPLATE](./.github/ISSUE_TEMPLATE) directory to apply appropriate labels such as `bug` and `untriaged`.  Repositories can choose to use GitHub actions such as [add-untriaged.yml](./.github/workflows/add-untriaged.yml) to apply labels automatically.
 
 ### Be Responsive
 

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -5,6 +5,7 @@
   - [Prioritize Security](#prioritize-security)
   - [Review Pull Requests](#review-pull-requests)
   - [Triage Open Issues](#triage-open-issues)
+    - [Automatically Label Issues](#automatically-label-issues)
   - [Be Responsive](#be-responsive)
   - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
     - [Keep Dependencies up to Date](#keep-dependencies-up-to-date)
@@ -56,6 +57,10 @@ Manage labels, review issues regularly, and triage by labelling them.
 All repositories in this organization have a standard set of labels, including `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `blocker`, `invalid`, `question`, `wontfix`, and `untriaged`, along with release labels, such as `v1.0.0`, `v1.1.0`, `v2.0.0`, `patch`, and `backport`.
 
 Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
+
+#### Automatically Label Issues
+
+There are many tools available in GitHub for controlling labels on issues and pull requests.  Use standard issue templates in the [./.github/ISSUE_TEMPLATE](./.github/ISSUE_TEMPLATE) directory to apply appropriate labels such as `bug` and `untriaged`.  Repositories can choose to use GitHub actions such as [add-untriaged.yml](.github\workflows\add-untriaged.yml) to apply labels automatically.
 
 ### Be Responsive
 


### PR DESCRIPTION
### Description
There has been discussion around how to be sure that issues are properly being marked and triaged.  To remove the human element from reviewing issues and adding the 'untriaged' label it it was missed I've added a github workflow to add 'untriaged' label during issue lifecycle event

### Testing
On my fork of this repo I enabled issues and created a couple and they were automatically tagged on open [1] and reopen [2]  by the github action bot for various scenarios [2].

[1] https://github.com/peternied/.github/issues/4
[2] https://github.com/peternied/.github/issues/6
[3] https://github.com/peternied/.github/actions 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
