### PR TITLE
Add style guidelines references to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [Welcome!](#welcome)
 - [Project Resources](#project-resources)
+- [Project Style Guidelines](#project-style-guidelines)
 - [Code of Conduct](#code-of-conduct)
 - [License](#license)
 - [Copyright](#copyright)
@@ -23,6 +24,10 @@
 * [Organization Admins](ADMINS.md)
 * [Repo Maintainers](MAINTAINERS.md)
 * [Security](SECURITY.md)
+
+## Project Style Guidelines
+
+The [OpenSearch Project style guidelines](https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md) and [OpenSearch terms](https://github.com/opensearch-project/documentation-website/blob/main/TERMS.md) documents provide style standards and terminology to be observed when creating OpenSearch Project content.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Add STYLE_GUIDE.md and TERMS.md cross-references to README.md for top-level visibility.

### Description
_Adds STYLE_GUIDE.md and TERMS.md cross-references to README.md for top-level visibility._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
