### PR TITLE
Adds a check on pull requests for baking time

### DIFF
--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -1,0 +1,20 @@
+name: Bake time
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */1 * * *' # Runs every 1 hour 
+
+jobs:
+  baking_pull_request:
+    name: "Baking pull request..."
+    runs-on: ubuntu-latest
+    steps:
+    - uses: peternied/bake-time@v2
+      with:
+        check-name: "Baking pull request..."
+        delay-hours: 48

--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -14,7 +14,7 @@ jobs:
     name: "Baking pull request..."
     runs-on: ubuntu-latest
     steps:
-    - uses: peternied/bake-time@v2
+    - uses: peternied/bake-time@v3
       with:
         check-name: "Baking pull request..."
         delay-hours: 48


### PR DESCRIPTION
### Description
After pull requests are updated, a 2 day waiting period is required to ensure plenty of time for additional reviews and comments.

This repository handles changes that are sensitive to the OpenSearch-Project involving many maintainers/contributors by using a tool to enforce the 'bake time' it removes maintainers from having to remember how long to wait and communicates to contributors when a pull request is ready to merge.

The underlying github actions for this change are in https://github.com/peternied/bake-time to make this functionality reusable in other repositories.

### Issues
- Related https://github.com/opensearch-project/.github/issues/149 

### Additional Background

#### Problem
This .github repository represents OpenSearch-Project's policies, ideals, and intentions. This repository has no quality gates other than 2 approvals and a DCO check - making the way pull requests are accepted subjective based on which maintainers/contributors first responded.

#### Expectation
There should be mechanisms to ensure a minimum quality of the changes that are accepted into this repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
