### PR TITLE
Allowing admins to move maintainers to Emeritus.

### DIFF
--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -138,7 +138,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), the repo admin may revoke maintainer level access to the repository for security reasons. A maintainer can reach out to the repo admin to get their permissions reinstated.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the repo admin may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the repo admin at any time upon request.
 
 If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
 


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/opensearch-rs/pull/170#issuecomment-1544821681.

Until now, when a maintainer became unreachable we have been eventually revoking their maintain-level permissions to reduce the security blast ratio. This had no visible side effects, however with the use of CODEOWNERS these files now become invalid when that happens. Similarly, the MAINTAINERS file claims that someone is a maintainer, but in fact they aren't active, which may mean that the repo actually is unmaintained, or at least gives a false impression that it is.  

I propose to allow repo maintainers to move someone to Emeritus when that happens. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
