### PR TITLE
Update RESPONSIBILITIES.md to disambiguous admin role

### DIFF
--- a/ADMINS.md
+++ b/ADMINS.md
@@ -1,6 +1,6 @@
 - [Overview](#overview)
 - [Current Admins](#current-admins)
-- [Admin Responsibilities](#admin-responsibilities)
+- [Admin Permissions](#admin-permissions)
   - [Prioritize Security](#prioritize-security)
   - [Enforce Code of Conduct](#enforce-code-of-conduct)
   - [Add/Remove Maintainers](#addremove-maintainers)
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This document explains who the admins are (see below), what they do in opensearch project, and how they should be doing it. If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+This document explains who the admins are (see below), what they do in opensearch-project, and how they should be doing it. They are added with Admin-level permissions to every repositories in opensearch-project organization.  If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Admins
 
@@ -26,7 +26,7 @@ This document explains who the admins are (see below), what they do in opensearc
 | Charlotte Henkle   | [CEHENKLE](https://github.com/CEHENKLE) | Amazon      |
 | Zelin Hao          | [zelinh](https://github.com/CEHENKLE) | Amazon      |
 
-## Admin Permission
+## Admin Permissions
 
 Admins have [admin-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and protect the repository as follows.
 

--- a/ADMINS.md
+++ b/ADMINS.md
@@ -8,19 +8,27 @@
 
 ## Overview
 
-This document explains who the admins are (see below), what they do in this repo, and how they should be doing it. If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+This document explains who the admins are (see below), what they do in opensearch project, and how they should be doing it. If you're interested in becoming a maintainer, see [MAINTAINERS](MAINTAINERS.md). If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
 
 ## Current Admins
 
 | Admin              | GitHub ID                               | Affiliation |
 | ------------------ | --------------------------------------- | ----------- |
-| Charlotte Henkle   | [CEHENKLE](https://github.com/CEHENKLE) | Amazon      |
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)     | Amazon      |
-| Henri Yandell      | [hyandell](https://github.com/hyandell) | Amazon      |
+| Nick Knize         | [nknize](https://github.com/nknize)     | Amazon      |
+| Peter Nied         | [peternied](https://github.com/peternied)     | Amazon      |
+| William Beckler    | [wbeckler](https://github.com/wbeckler) | Amazon      |
+| Rishabh Singh      | [rishabh6788](https://github.com/rishabh6788) | Amazon      |
+| Prudhvi Godithi    | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon      |
+| Sayali Gaikawad    | [gaiksaya](https://github.com/gaiksaya) | Amazon      |
+| Peter Zhu          | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
+| Barani bbarani     | [bbarani](https://github.com/bbarani) | Amazon      |
+| Charlotte Henkle   | [CEHENKLE](https://github.com/CEHENKLE) | Amazon      |
+| Zelin Hao          | [zelinh](https://github.com/CEHENKLE) | Amazon      |
 
-## Admin Responsibilities
+## Admin Permission
 
-As an admin you own stewardship of the repository and its settings. Admins have [admin-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and protect the repository as follows.
+Admins have [admin-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and protect the repository as follows.
 
 ### Prioritize Security
 

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -38,7 +38,7 @@ Maintainers are active and visible members of the community, and have [maintain-
 
 ### Uphold Code of Conduct
 
-Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and [org admin](https://github.com/orgs/opensearch-project/teams/admin).
+Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin).
 
 ### Prioritize Security
 
@@ -106,7 +106,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the [org admin](https://github.com/orgs/opensearch-project/teams/admin).
+Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin).
 
 The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
@@ -126,7 +126,7 @@ Upon receiving three positive (+1) maintainer votes, and no vetoes (-1), from ot
 >
 > The maintainers have voted and agreed to this nomination.
 
-The [org admin](https://github.com/orgs/opensearch-project/teams/admin) adjusts the new maintainer’s permissions accordingly, and merges the pull request.
+The [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) adjusts the new maintainer’s permissions accordingly, and merges the pull request.
 
 ## Removing a Maintainer
 
@@ -134,14 +134,14 @@ Removing a maintainer is a disruptive action that the community of maintainers s
 
 ### Moving On
 
-There are plenty of reasons that might cause someone to want to take a step back or even a hiatus from a project. Existing maintainers can choose to leave the project at any time, with or without reason, by making a pull request to move themselves to the "Emeritus" section of MAINTAINERS.md, and asking an admin to remove their permissions.
+There are plenty of reasons that might cause someone to want to take a step back or even a hiatus from a project. Existing maintainers can choose to leave the project at any time, with or without reason, by making a pull request to move themselves to the "Emeritus" section of MAINTAINERS.md, and asking an [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) to remove their permissions.
 
 ### Inactivity
 
-Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [org admin](https://github.com/orgs/opensearch-project/teams/admin) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [org admin](https://github.com/orgs/opensearch-project/teams/admin) at any time upon request.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [org admin](https://github.com/orgs/opensearch-project/teams/admin) at any time upon request.
 
-If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The [org admin](https://github.com/orgs/opensearch-project/teams/admin) will seek out new maintainers and note the maintenance status in the repo README file.
+If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) will seek out new maintainers and note the maintenance status in the repo README file.
 
 ### Negative Impact on the Project
 
-Actions that negatively impact the project will be handled by the [org admin](https://github.com/orgs/opensearch-project/teams/admin), in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.
+Actions that negatively impact the project will be handled by the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin), in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -138,7 +138,7 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [org admin](https://github.com/orgs/opensearch-project/teams/admin) at any time upon request.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) at any time upon request.
 
 If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) will seek out new maintainers and note the maintenance status in the repo README file.
 

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -38,7 +38,7 @@ Maintainers are active and visible members of the community, and have [maintain-
 
 ### Uphold Code of Conduct
 
-Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin).
+Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md).
 
 ### Prioritize Security
 
@@ -106,7 +106,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin).
+Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md).
 
 The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
@@ -126,7 +126,7 @@ Upon receiving three positive (+1) maintainer votes, and no vetoes (-1), from ot
 >
 > The maintainers have voted and agreed to this nomination.
 
-The [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) adjusts the new maintainer’s permissions accordingly, and merges the pull request.
+The [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md) adjusts the new maintainer’s permissions accordingly, and merges the pull request.
 
 ## Removing a Maintainer
 
@@ -134,14 +134,14 @@ Removing a maintainer is a disruptive action that the community of maintainers s
 
 ### Moving On
 
-There are plenty of reasons that might cause someone to want to take a step back or even a hiatus from a project. Existing maintainers can choose to leave the project at any time, with or without reason, by making a pull request to move themselves to the "Emeritus" section of MAINTAINERS.md, and asking an [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) to remove their permissions.
+There are plenty of reasons that might cause someone to want to take a step back or even a hiatus from a project. Existing maintainers can choose to leave the project at any time, with or without reason, by making a pull request to move themselves to the "Emeritus" section of MAINTAINERS.md, and asking an [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md) to remove their permissions.
 
 ### Inactivity
 
-Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) at any time upon request.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md) at any time upon request.
 
-If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin) will seek out new maintainers and note the maintenance status in the repo README file.
+If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md) will seek out new maintainers and note the maintenance status in the repo README file.
 
 ### Negative Impact on the Project
 
-Actions that negatively impact the project will be handled by the [members of the admin team](https://github.com/orgs/opensearch-project/teams/admin), in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.
+Actions that negatively impact the project will be handled by the [members of the admin team](https://github.com/opensearch-project/.github/blob/main/ADMINS.md), in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -38,7 +38,7 @@ Maintainers are active and visible members of the community, and have [maintain-
 
 ### Uphold Code of Conduct
 
-Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and admins.
+Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and [org admin](https://github.com/orgs/opensearch-project/teams/admin).
 
 ### Prioritize Security
 
@@ -106,7 +106,7 @@ You can become a maintainer by actively [contributing](CONTRIBUTING.md) to any p
 
 ### Nomination
 
-Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the repo admin.
+Any current maintainer starts a private e-mail thread (until we have a better mechanism, e-mail addresses can usually be found via MAINTAINERS.md + DCO) with all other maintainers on that repository to discuss nomination using the template below. In order to be approved, at least three positive (+1) maintainer votes are necessary, and no vetoes (-1). In rare cases when there are fewer than three maintainers, the positive (+1) votes from all maintainers are required. Any disagreements can be escalated to the [org admin](https://github.com/orgs/opensearch-project/teams/admin).
 
 The nomination should clearly identify the person with their real name and a link to their GitHub profile, and the rationale for the nomination, with concrete example contributions.
 
@@ -126,7 +126,7 @@ Upon receiving three positive (+1) maintainer votes, and no vetoes (-1), from ot
 >
 > The maintainers have voted and agreed to this nomination.
 
-The repo admin adjusts the new maintainer’s permissions accordingly, and merges the pull request.
+The [org admin](https://github.com/orgs/opensearch-project/teams/admin) adjusts the new maintainer’s permissions accordingly, and merges the pull request.
 
 ## Removing a Maintainer
 
@@ -138,10 +138,10 @@ There are plenty of reasons that might cause someone to want to take a step back
 
 ### Inactivity
 
-Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the repo admin may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the repo admin at any time upon request.
+Maintainer status never expires. If a maintainer becomes inactive for a time (usually several months), or a maintainer can confirm that they are no longer involved with the project for any reason, the [org admin](https://github.com/orgs/opensearch-project/teams/admin) may make a pull request to move them to the "Emeritus" section of the MAINTAINERS.md, remove them from CODEOWNERS, and upon merging the pull request, revoke the maintainer level access. Any past maintainer can be reinstated via another pull request, and have their permissions restored by the [org admin](https://github.com/orgs/opensearch-project/teams/admin) at any time upon request.
 
-If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The repo admin will seek out new maintainers and note the maintenance status in the repo README file.
+If the repo is left without any maintainers, either by maintainer inactivity or moving on, the repo is considered unmaintained. The [org admin](https://github.com/orgs/opensearch-project/teams/admin) will seek out new maintainers and note the maintenance status in the repo README file.
 
 ### Negative Impact on the Project
 
-Actions that negatively impact the project will be handled by the admins, in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.
+Actions that negatively impact the project will be handled by the [org admin](https://github.com/orgs/opensearch-project/teams/admin), in coordination with other maintainers, in balance with the urgency of the issue. Examples would be [Code of Conduct](CODE_OF_CONDUCT.md) violations, deliberate harmful or malicious actions, and security risks.


### PR DESCRIPTION
### Description
Disambiguous admin role in the process. Repo admin is github role, in opensearch-project that means org admin. clarify this to allow community to locate right group people for help if need

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
