### PR TITLE
Update RESPONSIBILITIES.md

### DIFF
--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -63,8 +63,8 @@ It is important that commit messages are helpful in understanding the reasons fo
 
 Most repositories in [opensearch-project](https://github.com/opensearch-project) are configured to require commits to be squashed into a single commit when merging pull requests. If the pull request contains multiple commits then messages from all commits will be appended into a single message, which usually requires editing to produce a high quality commit message. When merging pull requests, edit commit messages by following these steps as much as possible:
 
-- The commit subject should be concise and clearly convey what is being merged.
-- The commit body should include the details (if any) about the commit, typically inline with the PR description.
+- The commit subject should be concise (ideally within 50 characters) and clearly convey what is being merged.
+- The commit body should include the details (if any, and possibly within 72 characters) about the commit, typically inline with the PR description.
 - The commit body should include the 'Signed-off-by:*' for all committers involved in the change and thereby indicating that all code contributors agree to the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
 - There need to be a matching 'Signed-Off-By:' line for the `This commit will be authored by *` email address otherwise backport DCO checks will fail.
 

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -65,7 +65,7 @@ Most repositories in [opensearch-project](https://github.com/opensearch-project)
 
 - The commit subject should be concise and clearly convey what is being merged.
 - The commit body should include the details (if any) about the commit, typically inline with the PR description.
-- The commit body should include the 'Signed-off-by:*' for all committers involved in the change and thereby indicating that they agree to the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+- The commit body should include the 'Signed-off-by:*' for all committers involved in the change and thereby indicating that the contributors agree to the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
 - There need to be a matching 'Signed-Off-By:' line for the `This commit will be authored by *` email address otherwise backport DCO checks will fail.
 
 ### Triage Open Issues

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -56,6 +56,17 @@ It's our responsibility to ensure the content and code in pull requests are corr
 - If a pull request is valuable but isn't gaining traction, consider reaching out to fulfill the necessary requirements. This way, the pull request can be merged, even if the work is done by several individuals.
 - Lastly, strive for progress, not perfection.
 
+### Merging a Pull Request 
+
+It is important that commit messages are helpful in understanding the reasons for a given commit and maintain good commit hygiene by only keeping the relevant information. 
+
+When a PR is going to be merged, our repositories are set to automatically squash the commits into a single commit. This process needs human intervention to produce high quality commit messages, with the following steps to be followed as much as possible:
+
+- The commit subject is clean and conveys what is being merged.
+- The commit body should include the details (if any) about the commit, typically inline with the PR description.
+- The commit body should include the 'Signed-Off-By:*' for all committers involved in the change.
+- There need to be a matching 'Signed-Off-By:' line for the `This commit will be authored by *` email address otherwise backport DCO checks will fail.
+
 ### Triage Open Issues
 
 Manage labels, review issues regularly, and triage by labelling them.

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -65,7 +65,7 @@ Most repositories in [opensearch-project](https://github.com/opensearch-project)
 
 - The commit subject should be concise and clearly convey what is being merged.
 - The commit body should include the details (if any) about the commit, typically inline with the PR description.
-- The commit body should include the 'Signed-Off-By:*' for all committers involved in the change.
+- The commit body should include the 'Signed-off-by:*' for all committers involved in the change and thereby indicating that they agree to the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
 - There need to be a matching 'Signed-Off-By:' line for the `This commit will be authored by *` email address otherwise backport DCO checks will fail.
 
 ### Triage Open Issues

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -4,6 +4,7 @@
   - [Uphold Code of Conduct](#uphold-code-of-conduct)
   - [Prioritize Security](#prioritize-security)
   - [Review Pull Requests](#review-pull-requests)
+  - [Merging a Pull Request](#merging-a-pull-request) 
   - [Triage Open Issues](#triage-open-issues)
     - [Automatically Label Issues](#automatically-label-issues)
   - [Be Responsive](#be-responsive)
@@ -60,9 +61,9 @@ It's our responsibility to ensure the content and code in pull requests are corr
 
 It is important that commit messages are helpful in understanding the reasons for a given commit and maintain good commit hygiene by only keeping the relevant information. 
 
-When a PR is going to be merged, our repositories are set to automatically squash the commits into a single commit. This process needs human intervention to produce high quality commit messages, with the following steps to be followed as much as possible:
+Most repositories in [opensearch-project](https://github.com/opensearch-project) are configured to require commits to be squashed into a single commit when merging pull requests. This process needs human intervention to produce high quality commit messages. When merging pull requests, edit merge messages by following these steps as much as possible:
 
-- The commit subject is clean and conveys what is being merged.
+- The commit subject should be concise and clearly convey what is being merged.
 - The commit body should include the details (if any) about the commit, typically inline with the PR description.
 - The commit body should include the 'Signed-Off-By:*' for all committers involved in the change.
 - There need to be a matching 'Signed-Off-By:' line for the `This commit will be authored by *` email address otherwise backport DCO checks will fail.

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -65,7 +65,7 @@ Most repositories in [opensearch-project](https://github.com/opensearch-project)
 
 - The commit subject should be concise and clearly convey what is being merged.
 - The commit body should include the details (if any) about the commit, typically inline with the PR description.
-- The commit body should include the 'Signed-off-by:*' for all committers involved in the change and thereby indicating that the contributors agree to the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+- The commit body should include the 'Signed-off-by:*' for all committers involved in the change and thereby indicating that all code contributors agree to the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
 - There need to be a matching 'Signed-Off-By:' line for the `This commit will be authored by *` email address otherwise backport DCO checks will fail.
 
 ### Triage Open Issues

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -61,7 +61,7 @@ It's our responsibility to ensure the content and code in pull requests are corr
 
 It is important that commit messages are helpful in understanding the reasons for a given commit and maintain good commit hygiene by only keeping the relevant information. 
 
-Most repositories in [opensearch-project](https://github.com/opensearch-project) are configured to require commits to be squashed into a single commit when merging pull requests. This process needs human intervention to produce high quality commit messages. When merging pull requests, edit merge messages by following these steps as much as possible:
+Most repositories in [opensearch-project](https://github.com/opensearch-project) are configured to require commits to be squashed into a single commit when merging pull requests. If the pull request contains multiple commits then messages from all commits will be appended into a single message, which usually requires editing to produce a high quality commit message. When merging pull requests, edit commit messages by following these steps as much as possible:
 
 - The commit subject should be concise and clearly convey what is being merged.
 - The commit body should include the details (if any) about the commit, typically inline with the PR description.


### PR DESCRIPTION
Add code merge responsibilities for maintainers.

### Description
https://github.com/opensearch-project/OpenSearch/issues/851
Pulling in code merge best practices from https://github.com/opensearch-project/security/pull/2134

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
