### PR TITLE
Added information on attending triage meetings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 * [Release Management](RELEASING.md)
 * [Organization Admins](ADMINS.md)
 * [Repo Maintainers](MAINTAINERS.md)
+* [Issue Triage](TRIAGING.md)
 * [Security](SECURITY.md)
 
 ## Project Style Guidelines

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -76,6 +76,8 @@ All repositories in this organization have a standard set of labels, including `
 
 Use labels to target an issue or a PR for a given release, add `help wanted` to good issues for new community members, and `blocker` for issues that scare you or need immediate attention. Request for more information from a submitter if an issue is not clear. Create new labels as needed by the project.
 
+See [TRIAGING](TRIAGING.md) for more information on how to attend triage meetings.
+
 #### Automatically Label Issues
 
 There are many tools available in GitHub for controlling labels on issues and pull requests.  Use standard issue templates in the [./.github/ISSUE_TEMPLATE](./.github/ISSUE_TEMPLATE) directory to apply appropriate labels such as `bug` and `untriaged`.  Repositories can choose to use GitHub actions such as [add-untriaged.yml](./.github/workflows/add-untriaged.yml) to apply labels automatically.

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -22,7 +22,7 @@ During each meeting we seek to address all new issues. However, should we run ou
 
 Meetings are hosted regularly and can be joined via the links posted on the [OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events. The events are typically titled `Development Backlog & Triage Meeting`.
 
-After joining the Zoom meeting, you can enable your video/voice to join the discussion. If you do not have a webcam or microphone available, you can still join in via the text chat.
+After joining the virtual meeting, you can enable your video/voice to join the discussion. If you do not have a webcam or microphone available, you can still join in via the text chat.
 
 If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to everyone in the meeting.
 
@@ -58,3 +58,7 @@ No. Due to the sensitive nature of security vulnerabilities, please report all p
 ### Who should I contact if I have further questions?
 
 We recommend using the [forum](https://forum.opensearch.org/) or [public Slack](https://opensearch.org/slack.html).
+
+### Code of Conduct
+
+All hosts and participants involved in Triage are expected to follow the [OpenSearch Project Code of Conduct](CODE_OF_CONDUCT.md).

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,6 +1,10 @@
 ## Issue Triage
 
-When a new issue is opened in a repo in the opensearch-project organization it is automatically labeled as `untriaged`. The maintainers of many active OpenSearch Project repos facilitate [weekly triage meetings](https://www.meetup.com/opensearch/events/) that are open to all, and attendance is encouraged for anyone who hopes to contribute, discuss a new or existing issue, or learn more about the project. Some examples include [core](https://github.com/opensearch-project/OpenSearch/blob/main/TRIAGING.md) and [security triage](https://github.com/opensearch-project/security/blob/main/TRIAGING.md). In addition, a "catch all" weekly triage meeting is held to quickly review untriaged issues in less active repos and ensure that no new issue is left unattended.
+When a new issue is opened in a repo in the opensearch-project GitHub org it is automatically labeled as `untriaged`. The maintainers of many active OpenSearch Project repos facilitate [weekly triage meetings](https://www.meetup.com/opensearch/events/) that are open to all, and attendance is encouraged for anyone who hopes to contribute, discuss a new or existing issue, or learn more about the project. Some examples include [core](https://github.com/opensearch-project/OpenSearch/blob/main/TRIAGING.md) and [security triage](https://github.com/opensearch-project/security/blob/main/TRIAGING.md). In addition, a "catch all" weekly triage meeting is held to quickly review untriaged issues in less active repos and ensure that no new issue is left unattended.
+
+### What is the purpose of triage meetings?
+
+The purpose of the triage meetings is to ensure every issue created in the opensearch-project GitHub org receives a response, and no security-related issue remains unattended. Many issues receive immediate engagement and do not need to be triaged. Triage meetings ensure that every issue is filed in the most appropriate repo and contains enough information to be actionable. Triage meetings do not seek to resolve or close all issues, as follow-up discussion and eventual resolution will happen on the issue itself.
 
 ### Which triage meeting should I attend?
 
@@ -8,7 +12,7 @@ You should attend the meeting for the repo where your issue was opened, or the "
 
 ### Do I need to attend for my issue to be addressed/triaged?
 
-Attendance is not required for your issue to be triaged or addressed. All new issues are triaged weekly.
+Attendance is always welcome, but requesters are not required to attend triage meetings in order for their issue to be addressed.
 
 ### What happens if my issue does not get covered this time?
 
@@ -29,14 +33,11 @@ Meetings are typically 60 minutes and structured as follows:
 1. Initial Gathering: As we gather, feel free to turn on video and engage in informal and open-to-all conversation. After a bit a volunteer will share their screen and proceed with the agenda.
 2. Announcements: If there are any announcements to be made they will happen at the start of the meeting.
 3. Review of New Issues: The meetings always start with reviewing all untriaged issues. For example, the "catch all" meeting reviews [untriaged issues](https://github.com/search?q=label%3Auntriaged+is%3Aopen++org%3Aopensearch-project&type=issues&ref=advsearch&s=created&o=asc), oldest first.
-4. Member Requests: Opportunity for any meeting member to ask for consideration of an issue or pull request.
-5. Untriaged Items: Review any issues that might have had the `untriaged` label removed, but require additional triage discussion.
-6. Pull Request Discussion: Review the status of outstanding pull requests if there's time.
-7. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
+4. Untriaged Items: Review any issues that might have had the `untriaged` label removed, but require additional triage discussion.
+5. Pull Request Discussion: Review the status of outstanding pull requests if there's time.
+6. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
 
 There is no specific ordering within each category.
-
-If you have an issue you would like to discuss but do not have the ability to attend the entire meeting, please attend when is best for you and signal that you have an issue to discuss when you arrive.
 
 ### Do I need to have already contributed to the project to attend a triage meeting?
 
@@ -52,7 +53,7 @@ If you have an existing issue you would like to discuss, you can always comment 
 
 ### Is this where I should bring up potential security vulnerabilities?
 
-Due to the sensitive nature of security vulnerabilities, please report all potential vulnerabilities directly by following the steps outlined in [SECURITY.md](https://github.com/opensearch-project/.github/blob/main/SECURITY.md). Do not create security issues on GitHub.
+No. Due to the sensitive nature of security vulnerabilities, please report all potential vulnerabilities directly by following the steps outlined in [SECURITY.md](https://github.com/opensearch-project/.github/blob/main/SECURITY.md). Do not create security issues on GitHub.
 
 ### Who should I contact if I have further questions?
 

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,0 +1,59 @@
+## Issue Triage
+
+When a new issue is opened in a repo in the opensearch-project organization it is automatically labeled as `untriaged`. The maintainers of many active OpenSearch Project repos facilitate [weekly triage meetings](https://www.meetup.com/opensearch/events/) that are open to all, and attendance is encouraged for anyone who hopes to contribute, discuss a new or existing issue, or learn more about the project. Some examples include [core](https://github.com/opensearch-project/OpenSearch/blob/main/TRIAGING.md) and [security triage](https://github.com/opensearch-project/security/blob/main/TRIAGING.md). In addition, a "catch all" weekly triage meeting is held to quickly review untriaged issues in less active repos and ensure that no new issue is left unattended.
+
+### Which triage meeting should I attend?
+
+You should attend the meeting for the repo where your issue was opened, or the "catch all" if your issue has not seen much traction for an extended period of time.
+
+### Do I need to attend for my issue to be addressed/triaged?
+
+Attendance is not required for your issue to be triaged or addressed. All new issues are triaged weekly.
+
+### What happens if my issue does not get covered this time?
+
+During each meeting we seek to address all new issues. However, should we run out of time before your issue is discussed, you are always welcome to attend the next meeting or to follow up on the issue post itself.
+
+### How do I join triage?
+
+Meetings are hosted regularly and can be joined via the links posted on the [OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events. The events are typically titled `Development Backlog & Triage Meeting`.
+
+After joining the Zoom meeting, you can enable your video/voice to join the discussion. If you do not have a webcam or microphone available, you can still join in via the text chat.
+
+If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to everyone in the meeting.
+
+### Is there an agenda for each week?
+
+Meetings are typically 60 minutes and structured as follows:
+
+1. Initial Gathering: As we gather, feel free to turn on video and engage in informal and open-to-all conversation. After a bit a volunteer will share their screen and proceed with the agenda.
+2. Announcements: If there are any announcements to be made they will happen at the start of the meeting.
+3. Review of New Issues: The meetings always start with reviewing all untriaged issues. For example, the "catch all" meeting reviews [untriaged issues](https://github.com/search?q=label%3Auntriaged+is%3Aopen++org%3Aopensearch-project&type=issues&ref=advsearch&s=created&o=asc), oldest first.
+4. Member Requests: Opportunity for any meeting member to ask for consideration of an issue or pull request.
+5. Untriaged Items: Review any issues that might have had the `untriaged` label removed, but require additional triage discussion.
+6. Pull Request Discussion: Review the status of outstanding pull requests if there's time.
+7. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
+
+There is no specific ordering within each category.
+
+If you have an issue you would like to discuss but do not have the ability to attend the entire meeting, please attend when is best for you and signal that you have an issue to discuss when you arrive.
+
+### Do I need to have already contributed to the project to attend a triage meeting?
+
+No, all are welcome and encouraged to attend. Attending the Backlog & Triage meetings is a great way for a new contributor to learn about the project as well as explore different avenues of contribution.
+
+### What if I have an issue that is almost a duplicate, should I open a new one to be triaged?
+
+You can always open an issue including one that you think may be a duplicate. However, in cases where you believe there is an important distinction to be made between an existing issue and your newly created one, you are encouraged to attend the triage meeting to explain.
+
+### What if I have follow-up questions on an issue?
+
+If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you are welcome to come to the triage meeting to discuss.
+
+### Is this where I should bring up potential security vulnerabilities?
+
+Due to the sensitive nature of security vulnerabilities, please report all potential vulnerabilities directly by following the steps outlined in [SECURITY.md](https://github.com/opensearch-project/.github/blob/main/SECURITY.md). Do not create security issues on GitHub.
+
+### Who should I contact if I have further questions?
+
+We recommend using the [forum](https://forum.opensearch.org/) or [public Slack](https://opensearch.org/slack.html).


### PR DESCRIPTION
### Description

We've been seeing good results with public triage meetings in repos such as [core](https://github.com/opensearch-project/OpenSearch/blob/76e2a5d9d70ab310033f33151fdaa0ab68c6537e/TRIAGING.md), [security](https://github.com/opensearch-project/security/blob/382bc5f8558e138b2bf2618071e4c43da8acd63d/TRIAGING.md) or [ml-commons](https://github.com/opensearch-project/ml-commons/blob/99e75aaa3ff4d10c6461379abbad9fb793e44785/TRIAGING.md).

This is a proposal to:

1. Describe TRIAGING in more general terms.
2. Introduce a "catch all" triaging meeting for less active repos to ensure that no new issue is left unattended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
