### PR TITLE
Updating security reachout email

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -113,7 +113,7 @@ For the actual steps to build a release, please see [Releasing OpenSearch](https
 
 ### Security Reviews 
 
-If you discover a potential security issue in this project we ask that you notify the OpenSearch Security Team by email at opensearch-security@amazon.com. Please do not create a public GitHub issue. See [SECURITY.md](SECURITY.md) for more information on the security response process.
+If you discover a potential security issue in this project we ask that you notify the OpenSearch Security Team by email at security@opensearch.org. Please do not create a public GitHub issue. See [SECURITY.md](SECURITY.md) for more information on the security response process.
 
 The OpenSearch Project currently performs security reviews before releasing signed artifacts. These are typically conducted for any of the following:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,7 +73,7 @@ Pre-disclosure list members are allowed to share fixes to embargoed issues, anal
 
 ## Pre-disclosure list application process
 
-Organizations who meet the criteria above (i.e. significant work needed post-disclosure to remediate the issue and/or ability to help create or test the potential fixes) should contact the OpenSearch Security Team via email at opensearch-security@amazon.com if they wish to be added to the pre-disclosure list. In the email, you must include:
+Organizations who meet the criteria above (i.e. significant work needed post-disclosure to remediate the issue and/or ability to help create or test the potential fixes) should contact the OpenSearch Security Team via email at security@opensearch.org if they wish to be added to the pre-disclosure list. In the email, you must include:
 
 * The name of your organization
 * How you’re using OpenSearch


### PR DESCRIPTION
### Description
Updating security reachout email from [opensearch-security@amazon.com](mailto:opensearch-security@amazon.com) to [security@opensearch.org](mailto:security@opensearch.org)

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
