### PR TITLE
Fix onboarding link in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ OpenSearch is a community-driven, Apache 2.0-licensed open source search and ana
 
 We are built 🧱 by the community for the community. If you would like to contribute there are many ways:
 
-- We have [a step-by-step onboarding guide](ONBOARDING.md) to help you get oriented and prepared to contribute.
+- We have [a step-by-step onboarding guide](../ONBOARDING.md) to help you get oriented and prepared to contribute.
 - 👀 Check out a project's `CONTRIBUTING.md` file to learn how to contribute.
 - [Blogs](https://github.com/opensearch-project/project-website) and [Documentation Updates](https://github.com/opensearch-project/documentation-website)!
 - Finally, make sure to try [OpenSearch](https://opensearch.org/docs/latest/opensearch/install/docker/) 🔎, [OpenSearch Dashboards](https://playground.opensearch.org/app/home) 🖥, and our Plugins/Client Libraries 📚 and leave feedback!


### PR DESCRIPTION
### Description
The current org readme links to the onboarding guide at https://github.com/opensearch-project/.github/blob/main/profile/ONBOARDING.md, which is a 404. This updates the link to the correct location.

It may at some point be worthwhile to run a link checker in the repo to find other dead links.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
