### PR TITLE
Add link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -10,7 +10,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429 "./**/*.md" "./**/*.txt" --max-redirects=15
+          args: --accept=200,403,429 "./**/*.md" "./**/*.txt"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Fail if there were link errors

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,9 +1,5 @@
 name: Link Checker
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   linkchecker:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -14,7 +14,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@master
         with:
-          args: --accept=200,403,429 "./**/*.md" "./**/*.txt"
+          args: --accept=200,403,429 "./**/*.md" "./**/*.txt" --max-redirects=15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Fail if there were link errors

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,21 @@
+name: Link Checker
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  linkchecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: lychee Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: --accept=200,403,429 "./**/*.md" "./**/*.txt"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail if there were link errors
+        run: exit ${{ steps.lychee.outputs.exit_code }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://playground.opensearch.org/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ OpenSearch is a community project that is built and maintained by people just li
 
 ## First Things First
 
-1. **When in doubt, open an issue** - For almost any type of contribution, the first step is opening an issue. Even if you think you already know what the solution is, writing down a description of the problem you're trying to solve will help everyone get context when they review your pull request. If it's truly a trivial change (e.g. spelling error), you can skip this step -- but as the subject says, when it doubt, [open an issue](../../issues).
+1. **When in doubt, open an issue** - For almost any type of contribution, the first step is opening an issue. Even if you think you already know what the solution is, writing down a description of the problem you're trying to solve will help everyone get context when they review your pull request. If it's truly a trivial change (e.g. spelling error), you can skip this step -- but as the subject says, when it doubt, [open an issue](https://github.com/opensearch-project/.github/issues).
 
 2. **Only submit your own work**  (or work you have sufficient rights to submit) - Please make sure that any code or documentation you submit is your work or you have the rights to submit. We respect the intellectual property rights of others, and as part of contributing, we'll ask you to sign your contribution with a "Developer Certificate of Origin" (DCO) that states you have the rights to submit this work and you understand we'll use your contribution. There's more information about this topic in the [DCO section](#developer-certificate-of-origin).
 
@@ -34,7 +34,7 @@ Ugh! Bugs!
 
 A bug is when software behaves in a way that you didn't expect and the developer didn't intend. To help us understand what's going on, we first want to make sure you're working from the latest version.
 
-Once you've confirmed that the bug still exists in the latest version, you'll want to check to make sure it's not something we already know about on the [open issues GitHub page](../../issues).
+Once you've confirmed that the bug still exists in the latest version, you'll want to check to make sure it's not something we already know about on the [open issues GitHub page](https://github.com/opensearch-project/.github/issues).
 
 If you've upgraded to the latest version and you can't find it in our open issues list, then you'll need to tell us how to reproduce it Provide as much information as you can. You may think that the problem lies with your query, when actually it depends on how your data is indexed. The easier it is for us to recreate your problem, the faster it is likely to be fixed.
 
@@ -52,7 +52,7 @@ User documentation is maintained in the [documentation-website](https://github.c
 
 ### Contributing Code
 
-As with other types of contributions, the first step is to [open an issue on GitHub](../../issues/new/choose). Opening an issue before you make changes makes sure that someone else isn't already working on that particular problem. It also lets us all work together to find the right approach before you spend a bunch of time on a PR. So again, when in doubt, open an issue.
+As with other types of contributions, the first step is to [open an issue on GitHub](https://github.com/opensearch-project/.github/issues/new/choose). Opening an issue before you make changes makes sure that someone else isn't already working on that particular problem. It also lets us all work together to find the right approach before you spend a bunch of time on a PR. So again, when in doubt, open an issue.
 
 ## Developer Certificate of Origin
 
@@ -146,7 +146,7 @@ New files in your code contributions should contain the following license header
 
 ## Review Process
 
-We deeply appreciate everyone who takes the time to make a contribution. We will review all contributions as quickly as possible. As a reminder, [opening an issue](../../issues/new/choose) discussing your change before you make it is the best way to smooth the PR process. This will prevent a rejection because someone else is already working on the problem, or because the solution is incompatible with the architectural direction.
+We deeply appreciate everyone who takes the time to make a contribution. We will review all contributions as quickly as possible. As a reminder, [opening an issue](https://github.com/opensearch-project/.github/issues/new/choose) discussing your change before you make it is the best way to smooth the PR process. This will prevent a rejection because someone else is already working on the problem, or because the solution is incompatible with the architectural direction.
 
 During the PR process, expect that there will be some back-and-forth. Please try to respond to comments in a timely fashion, and if you don't wish to continue with the PR, let us know. If a PR takes too many iterations for its complexity or size, we may reject it. Additionally, if you stop responding we may close the PR as abandoned. In either case, if you feel this was done in error, please add a comment on the PR.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,10 +6,10 @@ OpenSearch is a community-driven, Apache 2.0-licensed open source search and ana
 
 We are built 🧱 by the community for the community. If you would like to contribute there are many ways:
 
-- We have [a step-by-step onboarding guide](ONBOARDING.md) to help you get oriented and prepared to contribute.
+- We have [a step-by-step onboarding guide](../ONBOARDING.md) to help you get oriented and prepared to contribute.
 - 👀 Check out a project's `CONTRIBUTING.md` file to learn how to contribute.
 - [Blogs](https://github.com/opensearch-project/project-website) and [Documentation Updates](https://github.com/opensearch-project/documentation-website)!
-- Finally, make sure to try [OpenSearch](https://opensearch.org/docs/latest/opensearch/install/docker/) 🔎, [OpenSearch Dashboards](https://playground.opensearch.org/app/home) 🖥, and our Plugins/Client Libraries 📚 and leave feedback!
+- Finally, make sure to try [OpenSearch](https://opensearch.org/docs/latest/opensearch/install/docker/) 🔎, [OpenSearch Dashboards](https://playground.opensearch.org/auth/anonymous) 🖥, and our Plugins/Client Libraries 📚 and leave feedback!
 
 ## Get Involved in our Community!
 


### PR DESCRIPTION
### Description
Following up on #205, this PR adds the Lychee link checking action we use on our team. I also went through and fixed all the lychee issues for the repo.

The `issues` links were false alarms since they did work correctly in the GitHub UI, but I still think refactoring makes it more portable, and adding exemptions to the checker for this would probably be more effort than it's worth.

The playground link being tricky is known, it gives a "too many redirects" error even after increasing the number of redirects. We ended up [ignoring it in our repo](https://github.com/opensearch-project/dashboards-observability/blob/main/.lycheeignore) as well, since this behavior happens even for dedicated redirect trackers like [deref](https://deref.link/). It's possible this behavior is due to some sort of bot protection.

```sh
> curl -d"url=https://playground.opensearch.org" https://deref.link/deref
{"error":"Too Many Redirects"}
```

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
