### PR TITLE
Update RESPONSIBILITIES.md

### DIFF
--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -45,7 +45,7 @@ Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and 
 
 Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs.
 
-Note that this repository is monitored and supported 24/7 by Amazon Security, see [Reporting a Vulnerability](SECURITY.md) for details.
+Note that this repository is monitored and OpenSearch Security team, see [Reporting a Vulnerability](SECURITY.md) for details.
 
 ### Review Pull Requests
 

--- a/RESPONSIBILITIES.md
+++ b/RESPONSIBILITIES.md
@@ -45,7 +45,7 @@ Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and 
 
 Security is your number one priority. Maintainer's Github keys must be password protected securely and any reported security vulnerabilities are addressed before features or bugs.
 
-Note that this repository is monitored and OpenSearch Security team, see [Reporting a Vulnerability](SECURITY.md) for details.
+Note that this repository is monitored and OpenSearch Security Team, see [Reporting a Vulnerability](SECURITY.md) for details.
 
 ### Review Pull Requests
 


### PR DESCRIPTION
This change removes Amazon Security and makes OpenSearch Security team responsible for security of the project

### Description
This change replaces Amazon Security with OpenSearch Security that is responsible for security of the project.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
