### PR TITLE
Add missing entrance criteria

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -131,6 +131,7 @@ Please note: this process is for regularly scheduled minor and patch releases. F
 
 ##### Entrance Criteria to Start Release Window
 
+* Each component release issue has an assigned owner.
 * Documentation draft PRs are up and in tech review for all component changes.
 * Sanity testing is done for all components.
 * Code coverage has not decreased (all new code has tests).


### PR DESCRIPTION
### Description
A new entrance criteria was added 6 months ago in the release template https://github.com/opensearch-project/opensearch-build/pull/4950
Looks like it missed this documentation.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
