### PR TITLE
Stop using bake-time action until it works with GHA updated security policies

### DIFF
--- a/.github/workflows/bake_time.yml
+++ b/.github/workflows/bake_time.yml
@@ -13,8 +13,12 @@ jobs:
   baking_pull_request:
     name: "Baking pull request..."
     runs-on: ubuntu-latest
+    env:
+      SLEEP_HOURS: 3 # Max GHA runner time is 6 hours 
     steps:
-      - uses: peternied/bake-time@v3
-        with:
-          check-name: "Baking pull request..."
-          delay-hours: 48
+      - name: Sleep to enforce bake time
+        run: |
+          echo "Sleeping for configured bake time of ${{ env.SLEEP_HOURS }} hours..."
+          sleep $(( ${{ env.SLEEP_HOURS }} * 3600 ))
+      - name: Bake complete
+        run: echo "Bake time completed successfully."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,10 @@
 - [Overview](#overview)
 - [Branching](#branching)
   - [OpenSearch Distribution Branching](#opensearch-distribution-branching)
-  - [Plugin Branching](#plugin-branching)
   - [Single Repo Artifacts Branching](#single-repo-artifacts-branching)
   - [Feature Branches](#feature-branches)
   - [Backporting](#backporting)
+  - [Breaking Changes](#breaking-changes)
 - [Versioning](#versioning)
   - [Version Numbers](#version-numbers)
     - [OpenSearch and OpenSearch Dashboards Version Numbers](#opensearch-and-opensearch-dashboards-version-numbers)
@@ -61,7 +61,7 @@ Because the `main` branch tracks the next minor version, we have no standardized
 
 ## Versioning
 
-All distributions in this organization [follow SemVer](https://opensearch.org/blog/technical-post/2021/08/what-is-semver/). A user-facing breaking change can only be made in a major release. Any regression that breaks SemVer is considered a high severity bug.
+All distributions in this organization [follow SemVer](https://opensearch.org/blog/what-is-semver/). A user-facing breaking change can only be made in a major release. Any regression that breaks SemVer is considered a high severity bug.
 
 ### Version Numbers
 


### PR DESCRIPTION
### Description
See related issue in the action's repo [1]
- [1] https://github.com/peternied/bake-time/issues/14

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
