### PR TITLE
Reflect current Security Response Team members

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,16 +16,24 @@ SRT will address reported issues on a best effort basis, prioritizing them based
 
 ### Current Members
 
-| Security Response Team   | GitHub Alias                                                | Affiliation |
+| Name                     | GitHub Alias                                                | Affiliation |
 | ------------------------ | ----------------------------------------------------------- | ----------- |
 | Kunal Khatua             | [kkhatua](https://github.com/kkhatua)                       | Amazon      |
-| Varun Lodaya             | [varun-lodaya](https://github.com/varun-lodaya)             | Amazon      |
 | Prabhat Chathurvedi      | [prabhat-chaturvedi](https://github.com/prabhat-chaturvedi) | Amazon      |
 | Craig Perkins            | [cwperks](https://github.com/cwperks)                       | Amazon      |
+| Shikhar Jain             | [shikharj05](https://github.com/shikharj05)                 | Amazon      |
+| Gulshan Kumar            | [kumargu](https://github.com/kumargu)                       | Amazon      |
+| Aayush Singhal           | [Aayush8394](https://github.com/Aayush8394)                 | Amazon      |
 | Nils Bandener            | [nibix](https://github.com/nibix)                           | Eliatra     |
-| Andrew Redko             | [reta](https://github.com/reta)                             | Aiven       |
-| Andrey Pleskach          | [willyborankin](https://github.com/willyborankin)           | Aiven       |
+
+### Emeritus
+
+| Name                     | GitHub Alias                                                | Affiliation |
+| ------------------------ | ----------------------------------------------------------- | ----------- |
 | Ryan Liang               | [RyanL1997](https://github.com/RyanL1997)                   | Amazon      |
+| Varun Lodaya             | [varun-lodaya](https://github.com/varun-lodaya)             | Amazon      |
+| Andriy Redko             | [reta](https://github.com/reta)                             | Aiven       |
+| Andrey Pleskach          | [willyborankin](https://github.com/willyborankin)           | Aiven       |
 
 ## Process
 


### PR DESCRIPTION
### Description

This PR updates the members of the Security Response Team to reflect the current composition.

We plan to create additional PRs after this one to start documentation SRT procedures similar to the k8s [security-response-committee](https://github.com/kubernetes/committee-security-response). Going forward, membership to this group will follow the maintainer nomination procedure for the rest of the project, but I am creating this PR now as this list is outdated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
