### PR TITLE
Move peternied to Emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CEHENKLE @mch2 @peternied @saratvemulapalli
+* @CEHENKLE @mch2 @saratvemulapalli

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,11 +12,11 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ----------------- | ------------------------------------------------------- | ----------- |
 | Charlotte Henkle  | [CEHENKLE](https://github.com/CEHENKLE)                 | Amazon      |
 | Marc Handalian    | [mch2](https://github.com/mch2)                         | Amazon      |
-| Peter Nied        | [peternied](https://github.com/peternied)               | Amazon      |
 | Sarat Vemulapalli | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
 
 ## Emeritus
 
 | Maintainer         | GitHub ID                           | Affiliation |
-| ------------------ | ----------------------------------- | ----------- |
-| Daniel Doubrovkine | [dblock](https://github.com/dblock) | Independent |
+| ------------------ | ------------------------------------------ | ----------- |
+| Daniel Doubrovkine | [dblock](https://github.com/dblock)        | Independent |
+| Peter Nied         | [peternied](https://github.com/peternied)  | Amazon      |


### PR DESCRIPTION
### Description
Move peternied to Emeritus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
