### PR TITLE
Add release Go/No-Go vote issue template (for async decision)

### DIFF
--- a/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
@@ -31,6 +31,12 @@ assignees: ''
 - A No-Go vote from any mandatory voter or maintainer of any `opensearch-project` repo blocks the release. No-Go votes must include an explicit comment with reasoning.
 - A No-Go vote from any community member or OpenSearch user will be reviewed, with the final decision resting on the maintainer of the respective repo related to the concern.
 
+## Discussion
+
+For questions and discussion, use the Slack thread in #releases: <SLACK_THREAD_LINK>
+
+> The Release Manager is responsible for surfacing any No-Go concerns raised in Slack as comments on this issue to ensure they are formally captured.
+
 ## Other Maintainers & Contributors
 
 All maintainers and community members are encouraged to vote using 👍 (Go) or 👎 (No-Go) reactions on the respective comments below.

--- a/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
@@ -11,6 +11,12 @@ assignees: ''
 **Date:** <DATE>
 **Time:** 8:00 AM PST – 8:00 PM PST
 
+## Release References
+
+- **Release Issue:** [opensearch-project/opensearch-build#XXXX](https://github.com/opensearch-project/opensearch-build/issues/XXXX)
+- **Release Notes Draft:** <LINK>
+- **Build Status:** <LINK>
+
 ## How to Vote
 
 - **Go:** React with 👍 on the **Go** comment below

--- a/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
@@ -26,11 +26,14 @@ assignees: ''
 | Website Maintainer | @ | |
 | Release Blog Owner | @ | |
 
-> A No-Go vote from any mandatory voter blocks the release.
+## Voting Rules
+
+- A No-Go vote from any mandatory voter or maintainer of any `opensearch-project` repo blocks the release. No-Go votes must include an explicit comment with reasoning.
+- A No-Go vote from any community member or OpenSearch user will be reviewed, with the final decision resting on the maintainer of the respective repo related to the concern.
 
 ## Other Maintainers & Contributors
 
-All other maintainers and contributors are encouraged to vote using 👍 (Go) or 👎 (No-Go) reactions on the respective comments below.
+All maintainers and community members are encouraged to vote using 👍 (Go) or 👎 (No-Go) reactions on the respective comments below.
 
 ## Release Checklist
 

--- a/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/RELEASE_GO_NOGO_TEMPLATE.md
@@ -1,0 +1,45 @@
+---
+name: 🚀 Release Go/No-Go Vote
+about: Async Go/No-Go decision for OpenSearch release
+title: '[RELEASE] Go/No-Go Vote - OpenSearch <VERSION>'
+labels: 'release'
+assignees: ''
+---
+
+## Voting Window
+
+**Date:** <DATE>
+**Time:** 8:00 AM PST – 8:00 PM PST
+
+## How to Vote
+
+- **Go:** React with 👍 on the **Go** comment below
+- **No-Go:** React with 👎 on the **No-Go** comment below **and** leave a comment with your reasoning so we can follow through
+
+## Mandatory Votes
+
+| Role | GitHub Handle | Vote |
+|------|--------------|------|
+| Release Manager | @ | |
+| OS Core Maintainer (1+) | @ | |
+| Documentation Maintainer | @ | |
+| Website Maintainer | @ | |
+| Release Blog Owner | @ | |
+
+> A No-Go vote from any mandatory voter blocks the release.
+
+## Other Maintainers & Contributors
+
+All other maintainers and contributors are encouraged to vote using 👍 (Go) or 👎 (No-Go) reactions on the respective comments below.
+
+## Release Checklist
+
+- [ ] All release-blocking issues resolved
+- [ ] Documentation ready
+- [ ] Release blog drafted
+- [ ] Website updates prepared
+- [ ] CI/CD pipelines green
+
+## Additional Context
+
+_Add any relevant links, notes, or context for this release._


### PR DESCRIPTION
Today the release manager conducts a [synchronous call](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#go-or-no-go) to gather Go/No-Go votes. Given the growth of the project and maintainers across multiple geographies, we need to move this process to async.

This PR adds a Go/No-Go issue template that enables async voting:

- Mandatory voters (Release Manager, Core Maintainer, Docs Maintainer, Website Maintainer, Release Blog Owner) vote within an 8am–8pm PST window
- Go: 👍 reaction on the Go comment
- No-Go: 👎 reaction + explicit comment with reasoning
- A No-Go from any mandatory voter or maintainer of any opensearch-project repo blocks the release
- A No-Go from any community member or OpenSearch user is reviewed, with the final decision resting on the maintainer of the respective repo related to the concern