### PR TITLE
Add Nagaraj G (GH: nagarajg17) to OpenSearch Security Response Team

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,7 @@ SRT will address reported issues on a best effort basis, prioritizing them based
 | Shikhar Jain             | [shikharj05](https://github.com/shikharj05)                 | Amazon      |
 | Gulshan Kumar            | [kumargu](https://github.com/kumargu)                       | Amazon      |
 | Nils Bandener            | [nibix](https://github.com/nibix)                           | Eliatra     |
+| Nagaraj G                | [nagarajg17](https://github.com/nagarajg17)                 | Amazon      |
 
 ### Emeritus
 


### PR DESCRIPTION
### Description

I have nominated and other members of the Security Response Team have agreed to add @nagarajg17 to the SRT of the OpenSearch project. 

Responsibilities for members of this team can be found at https://github.com/opensearch-project/security-response/pull/1. 

@nagarajg17 is currently a maintainer on the opensearch-migrations repo and has been engaged with Security for the project for a couple of years.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
