### PR TITLE
Update Peter Nied maintainer metadata

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,4 +19,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer         | GitHub ID                           | Affiliation |
 | ------------------ | ------------------------------------------ | ----------- |
 | Daniel Doubrovkine | [dblock](https://github.com/dblock)        | Independent |
-| Peter Nied         | [peternied](https://github.com/peternied)  | Amazon      |
+| Peter Nied         | [peternied](https://github.com/peternied)  | Airbnb      |


### PR DESCRIPTION
Updates Peter Nied's public maintainer metadata to use Airbnb affiliation and peter.nied@airbnb.com where the document supports an email field.